### PR TITLE
fix bug in scenegraph indexing

### DIFF
--- a/src/rx/scenegraph.cpp
+++ b/src/rx/scenegraph.cpp
@@ -265,6 +265,7 @@ int SceneGraph::index()
         std::set<std::string> config_set;
         config_map.clear();
         config_rmap.clear();
+        limits.clear();
         size_t i_frame=0;
         config_size = 0;
         for( auto itr = list.begin();


### PR DESCRIPTION
Limits need to be cleared before indexing. Limits are re-inserted in the correct order on line 294/295. Current implementation causes incorrect limits retrieved when calling aa_rx_sg_get_limit_*.
