### PR TITLE
Enable new ompl planner to be used with amino

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,8 @@ noinst_HEADERS = \
              include/amino/rx/scene_gl_internal.h \
              include/amino/rx/scene_sdl_internal.h \
              include/amino/rx/rxtype_internal.h \
-             include/amino/rx/scene_fcl.h
+             include/amino/rx/scene_fcl.h \
+             include/amino/rx/ompl/scene_ompl.h
 
 dist_pkgdata_DATA = src/mac/amino.mac
 

--- a/include/amino/rx/ompl/scene_ompl.h
+++ b/include/amino/rx/ompl/scene_ompl.h
@@ -1,0 +1,58 @@
+/* -*- mode: C++; c-basic-offset: 4; -*- */
+/* ex: set shiftwidth=4 tabstop=4 expandtab: */
+/*
+ * Copyright (c) 2015, Rice University
+ * All rights reserved.
+ *
+ * Author(s): Neil T. Dantam <ntd@rice.edu>
+ *
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holder the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef AMINO_RX_SCENE_OMPL_H
+#define AMINO_RX_SCENE_OMPL_H
+
+#include "amino/rx/ompl/scene_ompl_internal.h"
+
+/**
+ * @file scene_ompl.h
+ * @brief external header for hooking new ompl planner
+ */
+
+AA_API
+void aa_rx_mp_set_planner(struct aa_rx_mp *mp, ompl::base::Planner *p){
+    mp->set_planner(p);
+}
+
+AA_API
+amino::sgSpaceInformation::Ptr aa_rx_mp_get_space_information(const struct aa_rx_mp* mp){
+    return mp->space_information;
+}
+
+#endif /*AMINO_RX_SCENE_OMPL_H*/

--- a/include/amino/rx/ompl/scene_ompl_internal.h
+++ b/include/amino/rx/ompl/scene_ompl_internal.h
@@ -35,8 +35,8 @@
  *
  */
 
-#ifndef AMINO_RX_SCENE_OMPL_H
-#define AMINO_RX_SCENE_OMPL_H
+#ifndef AMINO_RX_SCENE_OMPL_INTERNAL_H
+#define AMINO_RX_SCENE_OMPL_INTERNAL_H
 
 #include "amino/rx/rxerr.h"
 #include "amino/rx/rxtype.h"
@@ -56,7 +56,7 @@
 #include <ompl/base/Planner.h>
 
 /**
- * @file scene_ompl.h
+ * @file scene_ompl_internal.h
  * @brief OMPL-specific motion planning
  */
 
@@ -97,4 +97,4 @@ struct aa_rx_mp {
     amino::sgWorkspaceGoal *lazy_samples;
 };
 
-#endif /*AMINO_RX_SCENE_OMPL_H*/
+#endif /*AMINO_RX_SCENE_OMPL_INTERNAL_H*/

--- a/src/rx/mp/ompl_kpiece.cpp
+++ b/src/rx/mp/ompl_kpiece.cpp
@@ -47,7 +47,7 @@
 
 #include "amino/rx/ompl/scene_state_space.h"
 #include "amino/rx/ompl/scene_state_validity_checker.h"
-#include "amino/rx/ompl/scene_ompl.h"
+#include "amino/rx/ompl/scene_ompl_internal.h"
 
 #include <ompl/geometric/planners/kpiece/LBKPIECE1.h>
 

--- a/src/rx/mp/ompl_rrt.cpp
+++ b/src/rx/mp/ompl_rrt.cpp
@@ -48,7 +48,7 @@
 
 #include "amino/rx/ompl/scene_state_space.h"
 #include "amino/rx/ompl/scene_state_validity_checker.h"
-#include "amino/rx/ompl/scene_ompl.h"
+#include "amino/rx/ompl/scene_ompl_internal.h"
 
 #include <ompl/base/Planner.h>
 #include <ompl/geometric/planners/rrt/RRTConnect.h>

--- a/src/rx/mp/ompl_sbl.cpp
+++ b/src/rx/mp/ompl_sbl.cpp
@@ -41,7 +41,7 @@
 #include "amino/rx/scene_sub.h"
 #include "amino/rx/ompl/scene_state_space.h"
 #include "amino/rx/ompl/scene_state_validity_checker.h"
-#include "amino/rx/ompl/scene_ompl.h"
+#include "amino/rx/ompl/scene_ompl_internal.h"
 
 #include <ompl/base/Planner.h>
 #include <ompl/geometric/planners/sbl/SBL.h>

--- a/src/rx/mp/scene_ompl.cpp
+++ b/src/rx/mp/scene_ompl.cpp
@@ -52,7 +52,7 @@
 #include "amino/rx/ompl/scene_state_space.h"
 #include "amino/rx/ompl/scene_state_validity_checker.h"
 #include "amino/rx/ompl/scene_workspace_goal.h"
-#include "amino/rx/ompl/scene_ompl.h"
+#include "amino/rx/ompl/scene_ompl_internal.h"
 
 
 #include <ompl/base/Planner.h>

--- a/src/rx/mp/workspace_goal.cpp
+++ b/src/rx/mp/workspace_goal.cpp
@@ -49,7 +49,7 @@
 
 
 #include "amino/rx/ompl/scene_workspace_goal.h"
-#include "amino/rx/ompl/scene_ompl.h"
+#include "amino/rx/ompl/scene_ompl_internal.h"
 
 namespace ob = ::ompl::base;
 


### PR DESCRIPTION
Enable new ompl planner to be used with amino by adding hooks for changing the planner as well as retrieving the spaceinformation pointer
