### PR TITLE
Uses the effort limits from an URDF as the acceleration limits (redo)

### DIFF
--- a/lisp/rx/scenefile/urdf.lisp
+++ b/lisp/rx/scenefile/urdf.lisp
@@ -123,6 +123,7 @@
      for axis = (urdf-joint-axis j)
      for tf = (tf* (amino:euler-rpy rpy) xyz)
      for limits = (joint-limits :effort-limit (urdf-joint-limit-effort j)
+                                :acceleration-limit (urdf-joint-limit-effort j)
                                 :velocity-limit (urdf-joint-limit-velocity j)
                                 :min-position (urdf-joint-limit-lower j)
                                 :max-position (urdf-joint-limit-upper j))


### PR DESCRIPTION
(Same as #19, needed to rebranch)

URDFs only contain joint limits, velocity limits, and effort limits.

However, amino makes the distinction between effort limits and acceleration limits, defaulting all scene graphs to have a acceleration limits of 0.

The ct package uses the acceleration limit to use parabolic blending on waypoint paths, and having an acceleration of 0 causes issues when blending.

This change sets the default acceleration limit to be existing effort limit, which is a more reasonable default.